### PR TITLE
Add read-only calendar for white-label clients

### DIFF
--- a/upload_post/api_client.py
+++ b/upload_post/api_client.py
@@ -864,7 +864,11 @@ class UploadPostClient:
         redirect_url: Optional[str] = None,
         logo_image: Optional[str] = None,
         redirect_button_text: Optional[str] = None,
-        platforms: Optional[List[str]] = None
+        platforms: Optional[List[str]] = None,
+        show_calendar: Optional[bool] = None,
+        readonly_calendar: Optional[bool] = None,
+        connect_title: Optional[str] = None,
+        connect_description: Optional[str] = None
     ) -> Dict:
         """
         Generate a JWT for platform integration.
@@ -876,6 +880,10 @@ class UploadPostClient:
             logo_image: Logo image URL for the linking page.
             redirect_button_text: Text for redirect button.
             platforms: Platforms to show for connection.
+            show_calendar: Whether to show the calendar view.
+            readonly_calendar: Show only a read-only calendar (no editing, no account connection).
+            connect_title: Custom title for the connection page.
+            connect_description: Custom description for the connection page.
 
         Returns:
             JWT and connection URL.
@@ -889,6 +897,14 @@ class UploadPostClient:
             body["redirect_button_text"] = redirect_button_text
         if platforms:
             body["platforms"] = platforms
+        if show_calendar is not None:
+            body["show_calendar"] = show_calendar
+        if readonly_calendar is not None:
+            body["readonly_calendar"] = readonly_calendar
+        if connect_title:
+            body["connect_title"] = connect_title
+        if connect_description:
+            body["connect_description"] = connect_description
         return self._request("/uploadposts/users/generate-jwt", "POST", json_data=body)
 
     def validate_jwt(self, jwt: str) -> Dict:


### PR DESCRIPTION
# PR Description: Read-Only Calendar White-Label Support

## Overview
Implements read-only calendar mode for white-label clients, enabling secure calendar sharing with restricted editing capabilities. This allows customers to view scheduled posts and calendar data without modification permissions.

## Changes

### Backend Profile Management
- Added `readonly_calendar` parameter to profile JWT generation and validation
- Extends profile configuration to support read-only calendar mode as an optional feature
- Includes parameter extraction, storage, and change tracking for the new field
- Provides default fallback value (`False`) for backward compatibility with existing profiles

### Frontend Calendar Component Enhancement
- Added `readOnly` prop (default: `false`) to Calendar component for conditional rendering
- **Disabled Interactive Features in Read-Only Mode:**
  - Event editing and creation buttons
  - Drag-and-drop event rescheduling
  - Date/time selection
  - Composer modal access
  
- **Preserved View Features:**
  - Full calendar visualization
  - Event display and preview
  - Historical data access
  - Media preview functionality

### Key Implementation Details
- Calendar remains fully interactive when `readOnly={false}` (standard behavior)
- When `readOnly={true}`, all modification-related event handlers are disabled
- UI elements (buttons, modals) conditionally render based on read-only state
- Maintains complete backward compatibility with existing deployments

## Use Cases
- **White-Label Dashboards**: Clients can embed read-only calendar views without edit access
- **Client Demos**: Display scheduled content to end-users in view-only mode
- **Permission Management**: Control calendar access per client profile without separate code branches

## Backward Compatibility
✅ Fully backward compatible - defaults to standard editable calendar behavior when parameter not specified