### PR TITLE
Add Upload-POST feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,8 @@ boards = client.get_pinterest_boards("my-profile")
 ### Facebook
 - `facebook_page_id` - Facebook Page ID (required)
 - `video_state` - PUBLISHED, DRAFT
-- `facebook_media_type` - REELS, STORIES
+- `facebook_media_type` - REELS, STORIES, or VIDEO (normal page video)
+- `thumbnail_url` - Thumbnail URL for normal page videos (only when `facebook_media_type` is VIDEO)
 - `facebook_link_url` - URL for text posts
 
 ### Pinterest
@@ -265,6 +266,7 @@ boards = client.get_pinterest_boards("my-profile")
 - `share_with_followers` - Share community post with followers
 - `card_uri` - Card URI for Twitter Cards
 - `x_long_text_as_post` - Post long text as single post
+- `x_thread_image_layout` - Comma-separated image layout for thread (e.g. "4,4" or "2,3,1"). Each value 1-4, total must equal image count. Auto-chunks into groups of 4 when >4 images.
 
 ### Threads
 - `threads_long_text_as_post` - Post long text as single post (vs thread)

--- a/upload_post/api_client.py
+++ b/upload_post/api_client.py
@@ -253,7 +253,9 @@ class UploadPostClient:
                 data.append(("video_state", kwargs["video_state"]))
             if kwargs.get("facebook_media_type"):
                 data.append(("facebook_media_type", kwargs["facebook_media_type"]))
-        
+            if kwargs.get("thumbnail_url"):
+                data.append(("thumbnail_url", kwargs["thumbnail_url"]))
+
         if is_text and kwargs.get("facebook_link_url"):
             data.append(("facebook_link_url", kwargs["facebook_link_url"]))
 
@@ -307,6 +309,8 @@ class UploadPostClient:
                     data.append(("tagged_user_ids[]", uid))
             if kwargs.get("place_id"):
                 data.append(("place_id", kwargs["place_id"]))
+            if kwargs.get("x_thread_image_layout"):
+                data.append(("x_thread_image_layout", kwargs["x_thread_image_layout"]))
         else:
             if kwargs.get("post_url"):
                 data.append(("post_url", kwargs["post_url"]))
@@ -408,7 +412,8 @@ class UploadPostClient:
             Facebook:
                 facebook_page_id: Facebook Page ID
                 video_state: PUBLISHED or DRAFT
-                facebook_media_type: REELS or STORIES
+                facebook_media_type: REELS, STORIES, or VIDEO
+                thumbnail_url: Thumbnail URL for normal page videos (VIDEO type only)
             
             Pinterest:
                 pinterest_board_id: Board ID
@@ -533,10 +538,14 @@ class UploadPostClient:
                 nullcast: Promoted-only post
                 tagged_user_ids: User IDs to tag
                 x_long_text_as_post: Post long text as single post
-            
+                x_thread_image_layout: Comma-separated image layout for thread
+                    (e.g. "4,4" or "2,3,1"). Each value 1-4, total must equal
+                    image count. Auto-chunks into groups of 4 if >4 images
+                    and no layout specified.
+
             Threads:
                 threads_long_text_as_post: Post long text as single post
-            
+
             Reddit:
                 subreddit: Subreddit name (without r/)
                 flair_id: Flair template ID


### PR DESCRIPTION
# PR Description: Upload-Post

## Summary
Enhanced X (Twitter) photo upload functionality to support multi-tweet threading with configurable image layouts, enabling users to post more than 4 images by distributing them across multiple tweets in a thread.

## Changes

### Core Features Added
- **Custom Image Threading**: Introduced `x_thread_image_layout` parameter to specify image distribution across tweets (e.g., `"4,4"` or `"2,3,1"`)
- **Auto-threading Logic**: Automatically distributes images when count exceeds 4 without explicit layout specification
- **Validation**: Added validation to ensure layout values are between 1-4 and sum matches total image count

### Technical Improvements
- **Refactored Payload Builder**: Simplified `_build_tweet_payload()` function using boolean `attach_media` parameter for cleaner media attachment logic
- **Media Chunking**: Implemented chunking mechanism to organize images into groups corresponding to each tweet in the thread
- **Enhanced Logging**: Improved debug logging to track media chunks and thread structure (`chunks: [4, 3]` format)

### Behavioral Changes
- **Removed Hard Limit**: Replaced the hard 4-image limit with intelligent threading support
- **Conditional Long Text Mode**: Long text mode now only applies to single-tweet scenarios (when `len(media_chunks) <= 1`)
- **Thread-aware Processing**: Updated thread creation to account for both text parts and media chunks, ensuring proper tweet count calculation

## Key Benefits
- Users can now upload unlimited images by organizing them across a thread
- Granular control over image distribution per tweet
- Seamless fallback to auto-threading if no layout is specified
- Maintains backward compatibility for single-image and small batch uploads