### PR TITLE
Make TikTok titles optional, document 90-char limit

### DIFF
--- a/upload_post/api_client.py
+++ b/upload_post/api_client.py
@@ -6,7 +6,7 @@ Facebook, Pinterest, Threads, Reddit, Bluesky, and X (Twitter).
 """
 
 from pathlib import Path
-from typing import Dict, List, Union, Optional, Any, Literal
+from typing import Dict, List, Union, Optional, Any
 import requests
 
 
@@ -93,7 +93,7 @@ class UploadPostClient:
         self,
         data: List[tuple],
         user: str,
-        title: str,
+        title: Optional[str],
         platforms: List[str],
         first_comment: Optional[str] = None,
         alt_text: Optional[str] = None,
@@ -105,7 +105,8 @@ class UploadPostClient:
     ):
         """Add common upload parameters."""
         data.append(("user", user))
-        data.append(("title", title))
+        if title:
+            data.append(("title", title))
         for p in platforms:
             data.append(("platform[]", p))
         
@@ -345,9 +346,9 @@ class UploadPostClient:
     def upload_video(
         self,
         video_path: Union[str, Path],
-        title: str,
-        user: str,
-        platforms: List[str],
+        title: Optional[str] = None,
+        user: str = "",
+        platforms: Optional[List[str]] = None,
         **kwargs
     ) -> Dict:
         """
@@ -355,9 +356,10 @@ class UploadPostClient:
 
         Args:
             video_path: Path to video file or video URL.
-            title: Video title/caption.
+            title: Video title/caption. Required for YouTube and Reddit.
+                   Optional for TikTok, Instagram, Facebook, LinkedIn, X, Threads, Bluesky, Pinterest.
             user: User identifier (profile name).
-            platforms: Target platforms. Supported: tiktok, instagram, youtube, 
+            platforms: Target platforms. Supported: tiktok, instagram, youtube,
                       linkedin, facebook, pinterest, threads, bluesky, x
 
         Keyword Args:
@@ -486,9 +488,9 @@ class UploadPostClient:
     def upload_photos(
         self,
         photos: List[Union[str, Path]],
-        title: str,
-        user: str,
-        platforms: List[str],
+        title: Optional[str] = None,
+        user: str = "",
+        platforms: Optional[List[str]] = None,
         **kwargs
     ) -> Dict:
         """
@@ -496,7 +498,8 @@ class UploadPostClient:
 
         Args:
             photos: List of photo file paths or URLs.
-            title: Post title/caption.
+            title: Post title/caption. Required for Reddit.
+                   Optional for TikTok, Instagram, Facebook, LinkedIn, X, Threads, Bluesky, Pinterest.
             user: User identifier (profile name).
             platforms: Target platforms. Supported: tiktok, instagram, linkedin,
                       facebook, pinterest, threads, reddit, bluesky, x


### PR DESCRIPTION
Now I have the actual diff for `upload-post-pip`. Here's the PR description:

---

## TikTok: Make titles optional + document 90-char limit

### Summary

Makes the `title` parameter optional in the Python SDK to align with backend changes where titles are only required for specific platforms (YouTube, Reddit) rather than being globally mandatory.

### Changes

**`upload_post/api_client.py`**

- **`title` parameter now optional** in `upload_video()` and `upload_photos()` — changed type from `str` to `Optional[str]` with default `None`
- **Conditional title inclusion** in `_add_common_params()`: the `title` field is only appended to the request payload when a value is provided, preventing empty strings from being sent
- **Updated docstrings** to document which platforms require a title:
  - `upload_video()`: title required for YouTube and Reddit; optional for all others
  - `upload_photos()`: title required for Reddit; optional for all others
- **Relaxed positional parameter defaults**: `user` and `platforms` parameters in both upload methods now have defaults (`""` and `None`) to allow flexible keyword-argument usage
- **Removed unused import**: `Literal` removed from typing imports

### Context

This is part of a cross-repo change where:
- **Backend (sass-ai)**: Title validation is now platform-aware — only YouTube/Reddit require titles for video uploads; only Reddit requires them for photo uploads
- **Frontend (upload-post-app)**: Title field validation and submit button logic updated to reflect per-platform requirements; TikTok title input now shows a 90-character counter with `maxLength={90}`
- **SDK (this repo)**: API client updated to support optional titles