### PR TITLE
Add n8n vs direct API usage tracking

### DIFF
--- a/upload_post/api_client.py
+++ b/upload_post/api_client.py
@@ -45,7 +45,8 @@ class UploadPostClient:
         self.session = requests.Session()
         self.session.headers.update({
             "Authorization": f"Apikey {self.api_key}",
-            "User-Agent": "upload-post-python-client/2.0.0"
+            "User-Agent": "upload-post-python-client/2.0.0",
+            "X-Upload-Post-Source": "pip",
         })
 
     def _request(


### PR DESCRIPTION
Here's the PR description:

---

## Add `X-Upload-Post-Source` header for request origin tracking

Adds the `X-Upload-Post-Source: pip` header to all outgoing requests from the Python client. This allows the backend to distinguish requests originating from the pip package versus other integration sources (n8n, npm, dashboard, direct API calls).

### Changes

- **`upload_post/api_client.py`**: Added `"X-Upload-Post-Source": "pip"` to the default session headers in `UploadPostClient.__init__`, alongside the existing `Authorization` and `User-Agent` headers.

### Context

This is part of a cross-repository effort to tag each client SDK and integration with its source identifier. The backend uses a priority-based detection strategy (`X-Upload-Post-Source` header > dashboard form field > User-Agent sniffing > default `"api"`), and the `source` field is persisted in `uploadpost_stats` for analytics. By sending the header explicitly, the pip client ensures reliable attribution without relying on User-Agent parsing as a fallback.