### PR TITLE
Limit platforms per queue slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ These options work across all upload methods:
 | `scheduled_date` | ISO date for scheduling |
 | `timezone` | Timezone for scheduled date |
 | `add_to_queue` | Add to posting queue |
+| `max_posts_per_slot` | Max posts per queue slot (overrides profile setting) |
 | `async_upload` | Process asynchronously (default: True) |
 
 ## Error Handling

--- a/upload_post/api_client.py
+++ b/upload_post/api_client.py
@@ -100,6 +100,7 @@ class UploadPostClient:
         scheduled_date: Optional[str] = None,
         timezone: Optional[str] = None,
         add_to_queue: Optional[bool] = None,
+        max_posts_per_slot: Optional[int] = None,
         async_upload: Optional[bool] = None,
         **kwargs
     ):
@@ -109,7 +110,7 @@ class UploadPostClient:
             data.append(("title", title))
         for p in platforms:
             data.append(("platform[]", p))
-        
+
         if first_comment:
             data.append(("first_comment", first_comment))
         if alt_text:
@@ -120,6 +121,8 @@ class UploadPostClient:
             data.append(("timezone", timezone))
         if add_to_queue is not None:
             data.append(("add_to_queue", str(add_to_queue).lower()))
+        if max_posts_per_slot is not None:
+            data.append(("max_posts_per_slot", str(max_posts_per_slot)))
         if async_upload is not None:
             data.append(("async_upload", str(async_upload).lower()))
         


### PR DESCRIPTION
Here's the PR description:

---

## Summary

Adds support for the new `max_posts_per_slot` queue setting, allowing users to control how many posts can be scheduled in a single queue time slot. Previously, each slot was limited to exactly one post. This change enables overriding the profile-level setting on a per-request basis via the Python SDK.

## Changes

- **`upload_post/api_client.py`**: Added `max_posts_per_slot` parameter to `_add_common_params()`, which propagates it to all upload methods (`upload_video`, `upload_photos`, `upload_text`). When provided, the value is sent as a form parameter to the API, overriding the profile's default slot capacity.

- **`README.md`**: Documented `max_posts_per_slot` in the Common Options table as an optional override for the profile-level queue setting.

## Context

This corresponds to the backend changes in `sass-ai` that introduce:
- A configurable `max_posts_per_slot` setting per profile (stored in queue settings, default: 1)
- Slot capacity tracking using `Counter` instead of a binary occupied/free set
- A `full_slots` mechanism to mark specific slots as completely full
- Validation (must be a positive integer, max 100)

The SDK change lets API consumers pass `max_posts_per_slot` at upload time to override the server-side profile default, enabling use cases like batching multiple posts into a single time slot.