### PR TITLE
Add Reddit link post support

### DIFF
--- a/upload_post/api_client.py
+++ b/upload_post/api_client.py
@@ -349,6 +349,8 @@ class UploadPostClient:
             data.append(("subreddit", kwargs["subreddit"]))
         if kwargs.get("flair_id"):
             data.append(("flair_id", kwargs["flair_id"]))
+        if kwargs.get("reddit_link_url"):
+            data.append(("reddit_link_url", kwargs["reddit_link_url"]))
 
     def upload_video(
         self,
@@ -666,6 +668,8 @@ class UploadPostClient:
             Reddit:
                 subreddit: Subreddit name (without r/)
                 flair_id: Flair template ID
+                reddit_link_url: URL for a link post. Creates a link post
+                    (kind=link) instead of a text/self post.
 
         Returns:
             API response.
@@ -674,7 +678,7 @@ class UploadPostClient:
             UploadPostError: If upload fails.
         """
         data: List[tuple] = []
-        
+
         self._add_common_params(data, user, title, platforms, **kwargs)
         
         # Generic link_url support


### PR DESCRIPTION
Now I have a clear picture of all the changes. Here's the PR description:

---

## Summary

Adds support for Reddit link posts (`kind=link`) to the Python SDK client. When a `reddit_link_url` parameter is provided, the API creates a link post on Reddit instead of the default text/self post — matching the existing pattern used for LinkedIn, Facebook, and Bluesky link URLs.

## Changes

**`upload_post/api_client.py`**
- **`_add_reddit_params()`**: Added handling for the `reddit_link_url` parameter, appending it to the request form data when provided
- **`upload_text()` docstring**: Documented the new `reddit_link_url` keyword argument under the Reddit section, explaining it creates a link post (`kind=link`) instead of a text/self post

**Cross-repo context (backend + frontend):**
- **Backend (`uploadtext.py`)**: `upload_text_reddit()` now accepts `link_url` and conditionally builds either a `kind=link` or `kind=self` payload for the Reddit API
- **Backend (`uploadposts.py`)**: Extracts `reddit_link_url` / `link_url` from the request form and passes it through to the upload function
- **Frontend (`Dashboard.jsx`)**: New `redditLinkUrl` state wired into form submission, cURL generation, and reset logic
- **Frontend (`RedditOptions.jsx`)**: URL input field shown for text posts, allowing users to optionally convert a text post into a link post

## How it works

1. User provides a URL via `reddit_link_url` (or the generic `link_url` fallback)
2. The SDK client sends `reddit_link_url` as a form field to the API
3. The backend detects the URL and switches the Reddit API call from `kind=self` (text post) to `kind=link` (link post), passing the URL instead of body text
4. If no URL is provided, behavior is unchanged — a standard text/self post is created