### PR TITLE
Add get_job_status method to Python client

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ status = client.get_status("request_id_from_upload")
 print(status)
 ```
 
+For scheduled or queued posts, check the status using the job_id:
+
+```python
+status = client.get_job_status("job_id_from_scheduled_post")
+print(status)
+```
+
 ### Get Upload History
 
 ```python

--- a/upload_post/api_client.py
+++ b/upload_post/api_client.py
@@ -817,7 +817,7 @@ class UploadPostClient:
 
     def get_status(self, request_id: str) -> Dict:
         """
-        Get the status of an async upload.
+        Get the status of an async upload by request ID.
 
         Args:
             request_id: The request_id from an async upload.
@@ -826,6 +826,18 @@ class UploadPostClient:
             Upload status.
         """
         return self._request("/uploadposts/status", "GET", params={"request_id": request_id})
+
+    def get_job_status(self, job_id: str) -> Dict:
+        """
+        Get the status of a scheduled or queued upload by job ID.
+
+        Args:
+            job_id: The job_id from a scheduled or queued upload.
+
+        Returns:
+            Upload status.
+        """
+        return self._request("/uploadposts/status", "GET", params={"job_id": job_id})
 
     def get_history(self, page: int = 1, limit: int = 20) -> Dict:
         """


### PR DESCRIPTION
## Summary

Add `get_job_status()` method to the Python client, enabling status checks using `job_id` in addition to the existing `request_id`-based `get_status()` method.

The `/api/uploadposts/status` endpoint accepts both `request_id` and `job_id` query parameters, but the Python client only exposed the `request_id` variant. This adds the missing `get_job_status()` method for querying scheduled or queued posts by their job ID.

## Changes

- **`upload_post/api_client.py`**: Added `get_job_status(job_id)` method that calls `/uploadposts/status` with `job_id` as a query parameter. Updated docstring on existing `get_status()` to clarify it operates by request ID.
- **`README.md`**: Added usage example showing how to check status of scheduled/queued posts via `client.get_job_status()`.