### PR TITLE
Fix Instagram impressions metric returning 0

### DIFF
--- a/upload_post/api_client.py
+++ b/upload_post/api_client.py
@@ -852,7 +852,8 @@ class UploadPostClient:
             page_urn: LinkedIn page URN (defaults to "me" for personal profile).
 
         Returns:
-            Analytics data per platform.
+            Analytics data per platform. For Instagram, the response includes both
+            'views' (official Instagram metric) and 'impressions' (backwards-compatible alias).
         """
         params = {}
         if platforms:
@@ -885,10 +886,10 @@ class UploadPostClient:
             date: Single date in YYYY-MM-DD format.
             platforms: Filter by platforms.
             breakdown: Include per-platform and per-day breakdown.
-            metrics: Specific metrics to aggregate (e.g., ["likes", "comments", "shares"]).
+            metrics: Specific metrics to aggregate (e.g., ["likes", "comments", "shares", "views"]).
 
         Returns:
-            Total impressions data with optional breakdown.
+            Total impressions data with optional breakdown. For Instagram, uses 'reach' as the primary metric.
         """
         params: Dict[str, Any] = {}
         if period:


### PR DESCRIPTION
Now I have a clear picture. The changes in `api_client.py` are docstring updates reflecting the new `views` metric. Here's the PR description:

---

## Fix Instagram impressions metric returning 0

Instagram deprecated its `impressions` API metric in favor of `views`. This caused the impressions metric to return 0 for Instagram profiles across the analytics pipeline.

### Changes

**Backend (`sass-ai`)**
- Added `views` to `METRIC_KEYS` in the daily analytics cron snapshot
- Added `views` as an available metric for Instagram in `PLATFORM_METRICS_CONFIG`
- Mapped both `views` and `impressions` to the Instagram API's `impressions` response value, maintaining backwards compatibility
- Added `views` to the valid metric keys whitelist in `get_total_impressions`

**Frontend (`upload-post-app`)**
- Updated the Impressions tooltip to correctly list Instagram under "views" instead of "reach"

**Python SDK (`upload-post-pip`)**
- Updated `get_analytics` and `get_total_impressions` docstrings to document the new `views` metric and its relationship to the deprecated `impressions` field

**Docs (`upload-post-docs`)**
- Updated API documentation with realistic example values (replacing zeros)
- Documented `views` as a new metric and `impressions` as a backwards-compatible alias for Instagram/YouTube/TikTok
- Added `views` to the available metrics list for the `metrics` query parameter

### Root cause

Instagram's API replaced `impressions` with `views`. The backend was only storing/returning the old field name, which Instagram now returns as 0. The fix adds `views` as the canonical field while keeping `impressions` as an alias for backwards compatibility.