### PR TITLE
Add Threads topic tag support to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ boards = client.get_pinterest_boards("my-profile")
 ### Threads
 - `threads_long_text_as_post` - Post long text as single post (vs thread)
 - `threads_thread_media_layout` - Comma-separated list of how many media items to include in each Threads post (e.g. "5,5" or "3,4,3"). Each value 1-10, total must equal media count. Auto-chunks into groups of 10 when >10 items.
+- `threads_topic_tag` - Topic tag for the Threads post (1-50 characters, no periods or ampersands). One tag per post. Helps increase reach.
 
 ### Reddit
 - `subreddit` - Subreddit name (without r/)

--- a/upload_post/api_client.py
+++ b/upload_post/api_client.py
@@ -342,6 +342,8 @@ class UploadPostClient:
             data.append(("threads_long_text_as_post", str(kwargs["threads_long_text_as_post"]).lower()))
         if kwargs.get("threads_thread_media_layout"):
             data.append(("threads_thread_media_layout", kwargs["threads_thread_media_layout"]))
+        if kwargs.get("threads_topic_tag"):
+            data.append(("threads_topic_tag", kwargs["threads_topic_tag"]))
 
     def _add_reddit_params(self, data: List[tuple], is_text: bool = False, **kwargs):
         """Add Reddit-specific parameters."""
@@ -449,6 +451,7 @@ class UploadPostClient:
             
             Threads:
                 threads_long_text_as_post: Post long text as single post
+                threads_topic_tag: Topic tag for the post (1-50 chars, no periods or ampersands)
 
         Returns:
             API response with request_id for async uploads.
@@ -566,6 +569,7 @@ class UploadPostClient:
                     (e.g. "5,5", "3,4,3", or "0,1"). Each value 0-10, total must
                     equal media count. 0 means no media for that post. Auto-chunks
                     into groups of 10 if >10 items and no layout specified.
+                threads_topic_tag: Topic tag for the post (1-50 chars, no periods or ampersands)
 
             Reddit:
                 subreddit: Subreddit name (without r/)
@@ -680,6 +684,7 @@ class UploadPostClient:
 
             Threads:
                 threads_long_text_as_post: Post long text as single post
+                threads_topic_tag: Topic tag for the post (1-50 chars, no periods or ampersands)
 
             Reddit:
                 subreddit: Subreddit name (without r/)


### PR DESCRIPTION
Here's the PR description:

---

## Summary

Adds support for the Threads **topic tag** feature across all upload types (video, photo, and text). Topic tags are a Threads API feature that lets creators categorize posts by topic to increase discoverability and reach.

## Changes

### Backend (`sass-ai`)
- **`uploadposts.py`** — Extracts and validates `threads_topic_tag` from request form data in both `upload_to_platforms` and `upload_photos_to_platforms` endpoints. Validation enforces max 50 characters and rejects periods (`.`) and ampersands (`&`) per Threads API requirements.
- **`uploadphotos.py`** — Threads the `threads_topic_tag` parameter through `upload_photo_threads()`, applying it to single-image container params and carousel creation for the first post in a thread.
- **`uploadtext.py`** — Passes `threads_topic_tag` through to the Threads text upload flow.
- **`uploadvideos.py`** — Passes `threads_topic_tag` through to the Threads video upload flow.

### Python SDK (`upload-post-pip`)
- **`api_client.py`** — Adds `threads_topic_tag` to the `_add_threads_params` helper so it's sent as form data for all upload methods. Updates docstrings for `upload_video`, `upload_photos`, and `upload_text`.
- **`README.md`** — Documents the new `threads_topic_tag` option under the Threads platform-specific section.

## API Usage

```
threads_topic_tag=<string>   # 1-50 characters, no periods or ampersands, one per post
```

The tag is applied to the root post only (not replies in a thread), consistent with the Threads API behavior.

## Test Plan

- [ ] Upload a text post to Threads with a topic tag and verify it appears on the published post
- [ ] Upload photos (single and carousel) to Threads with a topic tag
- [ ] Upload a video to Threads with a topic tag
- [ ] Verify validation rejects tags over 50 characters
- [ ] Verify validation rejects tags containing `.` or `&`
- [ ] Verify omitting `threads_topic_tag` does not affect existing behavior
- [ ] Verify the Python SDK correctly passes `threads_topic_tag` through to the API