### PR TITLE
feat(media): add get_media() with LinkedIn page_urn support

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,23 @@ analytics = client.get_analytics(
 print(analytics)
 ```
 
+### Get Media
+
+Retrieve recent posts from a connected social account. Supported platforms:
+`instagram`, `tiktok`, `youtube`, `linkedin`, `facebook`, `x`, `threads`,
+`pinterest`, `bluesky`, `reddit`.
+
+```python
+# Personal LinkedIn profile (default for non-org accounts):
+media = client.get_media("linkedin", "my-profile")
+
+# Force the personal profile of an account connected as an org admin:
+media = client.get_media("linkedin", "my-profile", page_urn="me")
+
+# Target a specific LinkedIn organization page:
+media = client.get_media("linkedin", "my-profile", page_urn="12345")
+```
+
 ### Helper Methods
 
 ```python

--- a/upload_post/api_client.py
+++ b/upload_post/api_client.py
@@ -980,22 +980,17 @@ class UploadPostClient:
         page_urn: Optional[str] = None,
     ) -> Dict:
         """
-        Retrieve recent media (posts, reels, videos, pins, tweets) from a
-        connected social account.
+        Retrieve recent media from a connected social account.
 
         Args:
-            platform: One of instagram, tiktok, youtube, linkedin, facebook,
-                x, threads, pinterest, bluesky, reddit.
-            user: Profile username (as configured in Upload-Post).
-            page_urn: LinkedIn only. Numeric organization ID (e.g. ``"12345"``),
-                full URN (``"urn:li:organization:12345"``), or ``"me"`` to force
-                the personal profile. When omitted, accounts linked as an
-                organization admin auto-resolve to the first administered
-                organization; otherwise the personal profile is used.
+            platform: instagram, tiktok, youtube, linkedin, facebook, x,
+                threads, pinterest, bluesky, or reddit.
+            user: Profile username.
+            page_urn: LinkedIn only. Numeric org ID, full URN, or ``"me"`` to
+                force the personal profile of an org-admin account.
 
         Returns:
-            ``{"success": True, "media": [{"id", "caption", "media_type",
-            "media_url", "permalink", "timestamp", "thumbnail_url"}, ...]}``.
+            ``{"success": True, "media": [...]}``.
         """
         params: Dict[str, str] = {"platform": platform, "user": user}
         if page_urn:

--- a/upload_post/api_client.py
+++ b/upload_post/api_client.py
@@ -973,6 +973,35 @@ class UploadPostClient:
         """
         return self._request("/uploadposts/platform-metrics", "GET")
 
+    def get_media(
+        self,
+        platform: str,
+        user: str,
+        page_urn: Optional[str] = None,
+    ) -> Dict:
+        """
+        Retrieve recent media (posts, reels, videos, pins, tweets) from a
+        connected social account.
+
+        Args:
+            platform: One of instagram, tiktok, youtube, linkedin, facebook,
+                x, threads, pinterest, bluesky, reddit.
+            user: Profile username (as configured in Upload-Post).
+            page_urn: LinkedIn only. Numeric organization ID (e.g. ``"12345"``),
+                full URN (``"urn:li:organization:12345"``), or ``"me"`` to force
+                the personal profile. When omitted, accounts linked as an
+                organization admin auto-resolve to the first administered
+                organization; otherwise the personal profile is used.
+
+        Returns:
+            ``{"success": True, "media": [{"id", "caption", "media_type",
+            "media_url", "permalink", "timestamp", "thumbnail_url"}, ...]}``.
+        """
+        params: Dict[str, str] = {"platform": platform, "user": user}
+        if page_urn:
+            params["page_urn"] = page_urn
+        return self._request("/uploadposts/media", "GET", params=params)
+
     # ==================== Scheduled Posts ====================
 
     def list_scheduled(self) -> Dict:


### PR DESCRIPTION
## Summary
Surface the `/uploadposts/media` endpoint as a first-class SDK method. The `page_urn` argument maps to the backend's new LinkedIn auto-resolve / `me` override behavior.

## Changes
- `upload_post/api_client.py`: add `get_media(platform, user, page_urn=None)`.
- `README.md`: usage example for personal + organization LinkedIn fetches.

## Testing
- [ ] \`UploadPostClient(api_key).get_media("linkedin", "my-profile")\` → returns auto-resolved default.
- [ ] \`get_media("linkedin", "my-profile", page_urn="me")\` and \`page_urn="12345"\` both forward the param correctly.
- [ ] No regression on other platforms (\`instagram\`, \`x\`, …).

Co-Authored-By: Claude (noreply@anthropic.com)